### PR TITLE
Always pass Craft's absolute url to Flare

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Flare
 
+## 5.0.3 - 2025-02-21
+### Added
+- The plugin now always passes along the absolute url ([#2](https://github.com/studioespresso/craft-flare/pull/2))
+
 ## 5.0.2 - 2025-02-20
 ### Fixed
 - Fixed a typo in the namespace of the FlareService

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Flare.io integration for Craft CMS",
     "type": "craft-plugin",
     "license": "mit",
-    "version": "5.0.2",
+    "version": "5.0.3",
     "support": {
         "email": "support@studioespresso.co",
         "issues": "https://github.com/studioespresso/craft-flare/issues?state=open",

--- a/src/middleware/FlareMiddleware.php
+++ b/src/middleware/FlareMiddleware.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace studioespresso\flare\middleware;
+
+use Craft;
+use Spatie\FlareClient\Report;
+
+class FlareMiddleware
+{
+    public function handle(Report $report, $next)
+    {
+        $context = $report->allContext();
+        $context['request']['url'] = Craft::$app->getRequest()->getIsConsoleRequest() ? null : Craft::$app->getRequest()->getAbsoluteUrl();
+        $report->userProvidedContext($context);
+        return $next($report);
+    }
+}

--- a/src/services/FlareService.php
+++ b/src/services/FlareService.php
@@ -7,6 +7,7 @@ use craft\base\Component;
 use craft\helpers\App;
 use Spatie\FlareClient\Flare as FlareClient;
 use studioespresso\flare\Flare;
+use studioespresso\flare\middleware\FlareMiddleware;
 use studioespresso\flare\models\Settings as SettingsModel;
 
 /**
@@ -17,7 +18,6 @@ use studioespresso\flare\models\Settings as SettingsModel;
  */
 class FlareService extends Component
 {
-
     /**
      * @var FlareClient|null
      */
@@ -37,6 +37,7 @@ class FlareService extends Component
             Flare::getInstance()->getSettings()->enabled
         ) {
             $this->client = FlareClient::make(App::parseEnv($this->settings->apiKey))->registerFlareHandlers();
+            $this->client->registerMiddleware(FlareMiddleware::class);
         }
 
         parent::init();
@@ -51,7 +52,6 @@ class FlareService extends Component
         }
 
         if ($this->client) {
-
             if ($settings->anonymizeIp) {
                 $this->client->anonymizeIp();
             }


### PR DESCRIPTION
This PR passes Craft's `absoluteUrl` to Flare, instead of possible CDN or instance urls that may be passed on load-balanced hosting setups like Craft Cloud.

Note that I still need to test this on Craft Cloud myself.

To install the update from the branch, update your `composer.json` like so:

`"studioespresso/craft-flare": "dev-feature/craft-cloud as 5.0.3"`

And run `composer update`